### PR TITLE
Update BG Runway Definitions

### DIFF
--- a/GameData/NavInstruments/PluginData/makingHistoryRunways.cfg
+++ b/GameData/NavInstruments/PluginData/makingHistoryRunways.cfg
@@ -1,5 +1,5 @@
 //Dessert airfield runway heading 360
-NavUtilRunway
+Runway
 {
 	ident = DAF 36
 	shortID = DA36
@@ -18,7 +18,7 @@ NavUtilRunway
 }
 
 //Dessert airfield runway heading 180
-NavUtilRunway
+Runway
 {
 	ident = DAF 18
 	shortID = DA18


### PR DESCRIPTION
Runway Identifier still using the legacy "NavUtilRunway" format, corrected to use the current definition.